### PR TITLE
Introducing an option to convert BigInts to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ Succesfully catched expected exception on duplicate keys: {"name":"SyntaxError",
 
 ```
 
+#### options.storeAsString, boolean, default false
+Specifies if BigInts should be stored in the object as a string, rather than the default BigNumber.
+
+Note that this is a dangerous behavior as it breaks the default functionality of being able to convert back-and-forth without data type changes (as this will convert all BigInts to be-and-stay strings).
+
+example:
+```js
+var JSONbig = require('json-bigint');
+var JSONbigString = require('json-bigint')({"storeAsString": true});
+var key = '{ "key": 1234567890123456789 }';
+console.log('\n\nStoring the BigInt as a string, instead of a BigNumber');
+console.log('Input:', key);
+var withInt = JSONbig.parse(key);
+var withString = JSONbigString.parse(key);
+console.log('Default type: %s, With option type: %s', typeof withInt.key, typeof withString.key);
+
+```
+
+Output
+```
+Storing the BigInt as a string, instead of a BigNumber
+Input: { "key": 1234567890123456789 }
+Default type: object, With option type: string
+
+```
+
 
 ### Links:
 - [RFC4627: The application/json Media Type for JavaScript Object Notation (JSON)](http://www.ietf.org/rfc/rfc4627.txt)

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -75,7 +75,8 @@ var json_parse = function (options) {
 
 // Default options one can override by passing options to the parse()
     var _options = {
-        "strict": false  // not being strict means do not generate syntax errors for "duplicate key"
+        "strict": false,  // not being strict means do not generate syntax errors for "duplicate key"
+        "storeAsString": false // toggles whether the values should be stored as BigNumber (default) or a string
     };
 
 
@@ -83,6 +84,9 @@ var json_parse = function (options) {
     if (options !== undefined && options !== null) {
         if (options.strict === true) {
             _options.strict = true;
+        }
+        if (options.storeAsString === true) {
+            _options.storeAsString = true;
         }
     }
 
@@ -170,7 +174,7 @@ var json_parse = function (options) {
                 //if (number > 9007199254740992 || number < -9007199254740992)
                 // Bignumber has stricter check: everything with length > 15 digits disallowed
                 if (string.length > 15)
-                   return new BigNumber(string);
+                   return (_options.storeAsString === true) ? string : new BigNumber(string);
                 return number;
             }
         },

--- a/test/string-option-test.js
+++ b/test/string-option-test.js
@@ -1,0 +1,21 @@
+var mocha  = require('mocha')
+  , assert = require('chai').assert
+  , expect = require('chai').expect
+  ;
+
+describe("Testing 'storeAsString' option", function(){
+    var key = '{ "key": 12345678901234567 }';
+    it("Should show that the key is of type object", function(done){
+        var JSONbig = require('../index');
+        var result = JSONbig.parse(key);
+        expect(typeof result.key).to.equal("object");
+        done();
+    });
+
+    it("Should show that key is of type string, when storeAsString option is true", function(done){
+        var JSONstring = require('../index')({"storeAsString": true});
+        var result = JSONstring.parse(key);
+        expect(typeof result.key).to.equal("string");
+        done();
+    });
+});


### PR DESCRIPTION
This PR adds an option to have the system to the bigints in the object as a string rather than a BigNumber. It adds a test, and an example in the README (as well as a warning discouraging people from using it.)