### PR TITLE
Use duck-typing for BigNumber when instanceof fails

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -204,6 +204,16 @@ var JSON = module.exports;
     }
 
 
+    function isBigNumberLike(value) {
+        if (value == null || typeof value !== 'object') {
+            return false;
+        }
+
+        return value instanceof BigNumber || value.constructor.name === 'BigNumber' ||
+                (value.hasOwnProperty('c') && value.hasOwnProperty('e') && value.hasOwnProperty('s'));
+    }
+
+
     function str(key, holder) {
 
 // Produce a string from holder[key].
@@ -215,7 +225,7 @@ var JSON = module.exports;
             mind = gap,
             partial,
             value = holder[key],
-            isBigNumber = value instanceof BigNumber;
+            isBigNumber = isBigNumberLike(value);
 
 // If the value has a toJSON method, call it to obtain a replacement value.
 


### PR DESCRIPTION
When using this library across JavaScript contexts, an object may
be an instanceof a BigNumber, but return false to
`instanceof BigNumber`. This occurs when the BigNumber was created
in a different JavaScript context.

This can happen in a Node environment if an application has a
dependency for `bignumber.js`. Depending on how the modules are
installed, `json-bigint` can use a different copy than the main
application. Then any BigNumber instances passed into `stringify`
aren't recognized as such and are formatted as strings instead.