### PR TITLE
Use BigNumber.isBigNumber

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -204,16 +204,6 @@ var JSON = module.exports;
     }
 
 
-    function isBigNumberLike(value) {
-        if (value == null || typeof value !== 'object') {
-            return false;
-        }
-
-        return value instanceof BigNumber || value.constructor.name === 'BigNumber' ||
-                (value.hasOwnProperty('c') && value.hasOwnProperty('e') && value.hasOwnProperty('s'));
-    }
-
-
     function str(key, holder) {
 
 // Produce a string from holder[key].
@@ -225,7 +215,7 @@ var JSON = module.exports;
             mind = gap,
             partial,
             value = holder[key],
-            isBigNumber = isBigNumberLike(value);
+            isBigNumber = value != null && (value instanceof BigNumber || value.isBigNumber);;
 
 // If the value has a toJSON method, call it to obtain a replacement value.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Andrey Sidorov <sidorares@yandex.ru>",
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "^2.4.0"
+    "bignumber.js": "^4.0.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
Switch to use the new BigNumber.isBigNumber property to determine if an object is a BigNumber. This was introduced in [BigNumber v4.0.0](https://github.com/MikeMcl/bignumber.js#400) and is more reliable than duck-typing the `c`, `e`, and `s` properties. Keep instanceof so this works with older versions of the BigNumber library if only used in a single JavaScript context.