### PR TITLE
#25 parse very big numeric values

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -166,15 +166,17 @@ var json_parse = function (options) {
                 }
             }
             number = +string;
-            if (!isFinite(number)) {
+
+            if (BigNumber == null)
+                BigNumber = require('bignumber.js');
+            var bigNumberValue = new BigNumber(string);
+            if (!bigNumberValue.isFinite()) {
                 error("Bad number");
             } else {
-                if (BigNumber == null)
-                  BigNumber = require('bignumber.js');
                 //if (number > 9007199254740992 || number < -9007199254740992)
                 // Bignumber has stricter check: everything with length > 15 digits disallowed
                 if (string.length > 15)
-                   return (_options.storeAsString === true) ? string : new BigNumber(string);
+                   return (_options.storeAsString === true) ? string : bigNumberValue;
                 return number;
             }
         },

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -175,7 +175,7 @@ var json_parse = function (options) {
             } else {
                 //if (number > 9007199254740992 || number < -9007199254740992)
                 // Bignumber has stricter check: everything with length > 15 digits disallowed
-                if (string.length > 15)
+                if (bigNumberValue.toFixed().length > 15)
                    return (_options.storeAsString === true) ? string : bigNumberValue;
                 return number;
             }

--- a/test/bigint-test.js
+++ b/test/bigint-test.js
@@ -28,4 +28,17 @@ describe("Testing bigint support", function(){
         expect(output).to.equal(input);
         done();
     });
+
+    it("Should be able to parse numeric values larger than 1.7976931348623157e+308", function(done){
+        var JSONbig = require('../index');
+        var veryBigInput = '{"big":3e+500}';
+
+        var obj = JSONbig.parse(veryBigInput);
+        expect(obj.big.toString(), "string from big int").to.equal("3e+500");
+        expect(obj.big, "instanceof big int").to.be.instanceof(BigNumber);
+
+        var output = JSONbig.stringify(obj);
+        expect(output).to.equal(veryBigInput);
+        done();
+    });
 });


### PR DESCRIPTION
1. Exchanged `if (!isFinite(number))` by `if (!bigNumberValue.isFinite())` and had to move this function a few lines down in this context, but I think this check is not necessary at all, because whenever a numeric value will be entered, it must be finite anyway.

2. Replaced `if (string.length > 15)`  by `if (bigNumberValue.toFixed().length > 15)` to ensure big numbers written in scientific notation will also be parsed to BigNumber objects.

3. Added a test case for evaluating my changes.



