### PR TITLE
Added named export for better TypeScript compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib-cov
 *.pid
 *.gz
 .*.swp
+.idea
 node_modules
 
 pids

--- a/index.js
+++ b/index.js
@@ -1,12 +1,18 @@
 var json_stringify = require('./lib/stringify.js').stringify;
 var json_parse     = require('./lib/parse.js');
 
-module.exports = function(options) {
+var newInstance = function(options) {
     return  {
         parse: json_parse(options),
         stringify: json_stringify
     }
 };
+
+module.exports = newInstance;
+
 //create the default method members with no options applied for backwards compatibility
 module.exports.parse = json_parse();
 module.exports.stringify = json_stringify;
+
+// for cleaner typescript API
+module.exports.newInstance = newInstance;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-bigint",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "JSON.parse with bigints support",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
TypeScript declaration files don't deal well with a mix of named and unnamed (default) exports. Adding a named member called "newInstance" allows us to use this library cleanly from TypeScript (type declaration file will be submitted to DefinitelyTyped if this PR is accepted and a new release is made).