### PR TITLE
Reduced memory usage when parsing many long string

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -191,12 +191,17 @@ var json_parse = function (options) {
 // When parsing for string values, we must look for " and \ characters.
 
             if (ch === '"') {
+                var startAt = at;
                 while (next()) {
                     if (ch === '"') {
+                        if (at - 1 > startAt)
+                            string += text.substring(startAt, at - 1);
                         next();
                         return string;
                     }
                     if (ch === '\\') {
+                        if (at - 1 > startAt)
+                            string += text.substring(startAt, at - 1);
                         next();
                         if (ch === 'u') {
                             uffff = 0;
@@ -213,8 +218,7 @@ var json_parse = function (options) {
                         } else {
                             break;
                         }
-                    } else {
-                        string += ch;
+                        startAt = at;
                     }
                 }
             }


### PR DESCRIPTION
### Test code
```js
 #!/usr/bin/env node

const BitcoinCore = require('bitcoin-core');

let conn = new BitcoinCore({
	host: 'localhost',
	port: 8332,
	network: 'mainnet',
	username: 'bitcoin',
	password: 'bitcoin'
});
		
let blockNum = 558355; // example

(async () => {
	let hash = await conn.getBlockHash(blockNum);

	let prev = Date.now();
	let ret = await conn.getBlockByHash(hash, {
		extension: 'json'
	});

	console.log(Date.now() - prev, process.memoryUsage().heapUsed);
})();
```

I Tested on my laptap

#### Before Output ( 5 times )

```
1660 264063048
1694 264984656
1708 264312088
1681 264337120
1691 265233768
```

#### After Output ( 5 times )

Faster(even include same network time) and about 1/10 memory usage
```
1298 29823136
1325 29790656
1316 29875392
1344 29941656
1298 29785832
```

