### PR TITLE
Update bignumber.js to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Andrey Sidorov <sidorares@yandex.ru>",
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "^8.0.0"
+    "bignumber.js": "^9.0.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
To avoid double dependency on it in a project that uses the latest BigNumber.

Previous PR: #31 