### PR TITLE
feat: now allows a custom number parser to be passed as an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,29 @@ const user = JSONbig.parse('{ "__proto__": { "admin": true }, "id": 12345 }');
 // => result is { id: 12345 }
 ```
 
+#### options.numberParser, function, default: built-in parser
+
+Pass in a custom parser whenever a numeric value is encountered.
+When set, ignores `options.storeAsString`, `options.useNativeBigInt`, and `options.alwaysParseAsBig`.
+
+```js
+let JSONbig = require('../index')({
+  // append " abc" to every number value found
+  numberParser: str => str + " abc"
+});
+
+JSONbig.parse('{"big":92233720368547758070,"small":123}');
+// result is { big: "92233720368547758070 abc","small":"123 abc"}
+
+JSONbig = require('../index')({
+  // convert every number value found into a BigInt
+  numberParser: str => BigInt(str)
+});
+
+JSONbig.parse('{"big":92233720368547758070,"small":123}');
+// result is { big: 92233720368547758070n,"small":123n}
+```
+
 ### Links:
 
 - [RFC4627: The application/json Media Type for JavaScript Object Notation (JSON)](http://www.ietf.org/rfc/rfc4627.txt)

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -130,6 +130,8 @@ var json_parse = function (options) {
         );
       }
     }
+
+    _options.numberParser = options.numberParser;
   }
 
   var at, // The index of the current character
@@ -201,6 +203,11 @@ var json_parse = function (options) {
           next();
         }
       }
+
+      if(_options.numberParser) {
+        return _options.numberParser(string);
+      }
+
       number = +string;
       if (!isFinite(number)) {
         error('Bad number');

--- a/test/bigint-parse-test.js
+++ b/test/bigint-parse-test.js
@@ -56,4 +56,14 @@ describe("Testing native BigInt support: parse", function () {
     expect(output).to.equal(input);
     done();
   });
+
+  it("Uses custom parser if provided", function(done) {
+    var JSONbig = require('../index')({
+      numberParser: str => str + " 14eeda86-0b52-4c63-845f-4b0a60fb667b"
+    });
+    var obj = JSONbig.parse(input);
+    var output = JSONbig.stringify(obj);
+    expect(output).to.equal('{"big":"92233720368547758070 14eeda86-0b52-4c63-845f-4b0a60fb667b","small":"123 14eeda86-0b52-4c63-845f-4b0a60fb667b"}');
+    done();
+  });
 });


### PR DESCRIPTION
> the PR looks ok, but I'm a bit worried about growing nimber of options like yours. Maybe we should move to much simple api, for example `toNumber()` callback that takes number-like string as an input and decides what to return - JS number, BigNumber or something else. If not present the behaviour is automatic ( BigNumber if not all integer digits can be preserved accurately )
> ~https://github.com/sidorares/json-bigint/pull/20#issuecomment-346708938

Is this what you had in mind @sidorares?