### PR TITLE
Add `objectBaseClass` option which can be set to `Object` instead of `null` to preserve prototype methods like `hasOwnProperty`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -88,6 +88,7 @@ var json_parse = function (options) {
     useNativeBigInt: false, // toggles whether to use native BigInt instead of bignumber.js
     protoAction: 'error',
     constructorAction: 'error',
+    objectBaseClass: null, // pass `Object` if you require prototype methods like `hasOwnProperty` for the compatibility with JSON.parse()
   };
 
   // If there are options, then use them to override the default _options
@@ -327,7 +328,7 @@ var json_parse = function (options) {
       // Parse an object value.
 
       var key,
-        object = Object.create(null);
+        object = Object.create(_options.objectBaseClass);
 
       if (ch === '{') {
         next('{');


### PR DESCRIPTION
Closes #38