### PR TITLE
Add support for scientific notation and long decimal numbers

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -206,20 +206,21 @@ var json_parse = function (options) {
         error('Bad number');
       } else {
         if (BigNumber == null) BigNumber = require('bignumber.js');
-        //if (number > 9007199254740992 || number < -9007199254740992)
-        // Bignumber has stricter check: everything with length > 15 digits disallowed
-        if (string.length > 15)
-          return _options.storeAsString
-            ? string
-            : _options.useNativeBigInt
-            ? BigInt(string)
-            : new BigNumber(string);
-        else
+        if (Number.isSafeInteger(number))
           return !_options.alwaysParseAsBig
             ? number
             : _options.useNativeBigInt
             ? BigInt(number)
             : new BigNumber(number);
+        else
+          // Number with fractional part should be treated as number(double) including big integers in scientific notation, i.e 1.79e+308
+          return _options.storeAsString
+            ? string
+            : /[\.eE]/.test(string)
+            ? number
+            : _options.useNativeBigInt
+            ? BigInt(string)
+            : new BigNumber(string);
       }
     },
     string = function () {

--- a/test/bigint-parse-test.js
+++ b/test/bigint-parse-test.js
@@ -9,7 +9,7 @@ describe("Testing native BigInt support: parse", function () {
     console.log('No native BigInt');
     return;
   }
-  var input = '{"big":92233720368547758070,"small":123}';
+  var input = '{"big":92233720368547758070,"small":123,"deci":1234567890.0123456,"shortExp":1.79e+308,"longExp":1.7976931348623157e+308}';
 
   it("Should show JSONbig does support parsing native BigInt", function (done) {
     var JSONbig = require('../index')({
@@ -35,6 +35,21 @@ describe("Testing native BigInt support: parse", function () {
     done();
   });
 
+  it("Should show JSONbig does support decimal and scientific notation parse/stringify roundtrip", function (done) {
+    var JSONbig = require('../index')({
+      "useNativeBigInt": true
+    });
+    var obj = JSONbig.parse(input);
+    expect(obj.deci.toString(), "decimal number").to.equal("1234567890.0123456");
+    expect(typeof obj.deci, "decimal number").to.equal('number');
+    expect(obj.shortExp.toString(), "short exponential number").to.equal("1.79e+308");
+    expect(typeof obj.shortExp, "short exponential number").to.equal('number');
+    expect(obj.longExp.toString(), "long exponential number").to.equal("1.7976931348623157e+308");
+    expect(typeof obj.longExp, "long exponential number").to.equal('number');
+    var output = JSONbig.stringify(obj);
+    expect(output).to.equal(input);
+    done();
+  });
 
   it("Should show JSONbig does support native Bigint parse/stringify roundtrip", function (done) {
     var JSONbig = require('../index')({


### PR DESCRIPTION
Fix `Uncaught SyntaxError: Cannot convert xxxxx to a BigInt` when encountering numbers in scientific notation or a wide decimal number(>15 chars).

This PR uses `Number.isSafeInteger` instead of `string.lenght > 15` to identify BigInt scenarios.
It also treat numbers with fractional parts(decimal) or numbers in scientific notation as Number(double) instead of trying to convert it into BigInt.
For example, `1.79e+308` should be treated as a double, not a long integer.

I added a `test` with additional test data to support my use case.
It would be nice if you can merge my Pull Request.  I am using my fork in the meantime.