### PR TITLE
Support alwaysParseAsBig with storeAsString

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -209,6 +209,8 @@ var json_parse = function (options) {
         if (Number.isSafeInteger(number))
           return !_options.alwaysParseAsBig
             ? number
+            : _options.storeAsString
+            ? string
             : _options.useNativeBigInt
             ? BigInt(number)
             : new BigNumber(number);

--- a/test/string-option-test.js
+++ b/test/string-option-test.js
@@ -18,4 +18,14 @@ describe("Testing 'storeAsString' option", function(){
         expect(typeof result.key).to.equal("string");
         done();
     });
+
+    it("Should show that key is of type string, JSONbig is forced parse as big and storeAsString option is true", function(done){
+        var JSONstring = require('../index')({
+          "storeAsString": true,
+          "alwaysParseAsBig": true,
+        });
+        var result = JSONstring.parse('{ "key": 1234 }');
+        expect(typeof result.key).to.equal("string");
+        done();
+    });
 });


### PR DESCRIPTION
When alwaysParseAsBig is set to true, and json-bigint encounters a safe number, it doesn't check whether storeAsString is true as well. This PR adds a check for storeAsString, similar to the ternary check when the encountered number is not safe.

I am using json-bigint to parse responses from an API server which passes down raw IDs via an HTTP API. No arithmetic is performed on these IDs, and they're passed back to the server on subsequent HTTP calls. This means storing numbers in the API server's responses as strings is very convenient, and just works when interoping with Node JS's native HTTP module, or with the `request` module.

A unit tests was also added to ensure this works correctly.