### PR TITLE
ci(github/workflows): add publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: 🚀 Publish 
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  test:
+    name: ⚡ Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+      
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+      
+      - name: ⚡ Run tests 
+        run: npm run test
+  
+  publish:
+    name: 🚀 Publish
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+    steps:
+      - name: 🛑 Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+      
+      - name: 🚀 Publish package 
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes #74; all you have to do @sidorares is:

1. Add an `NPM_TOKEN` secret to this repository (instructions [here](https://docs.npmjs.com/creating-and-viewing-access-tokens)).
2. Push a commit to `master` that bumps the `version` in `package.json` (see [`npm-publish`](https://github.com/JS-DevTools/npm-publish)).
3. This GitHub Action will run your tests and, if they pass, publish the new version to NPM.