### PR TITLE
Return +/- Infinity when a number exceeds the infiniy limits

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -173,10 +173,12 @@ var json_parse = function (options) {
       // Parse a number value.
 
       var number,
-        string = '';
+        string = '',
+        is_positive = true;
 
       if (ch === '-') {
         string = '-';
+        is_positive = false;
         next('-');
       }
       while (ch >= '0' && ch <= '9') {
@@ -202,8 +204,9 @@ var json_parse = function (options) {
         }
       }
       number = +string;
+      if (isNaN(number)) error(`Bad number`);
       if (!isFinite(number)) {
-        error('Bad number');
+        return is_positive ? Infinity : -Infinity;
       } else {
         if (BigNumber == null) BigNumber = require('bignumber.js');
         if (Number.isSafeInteger(number))

--- a/test/bigint-parse-test.js
+++ b/test/bigint-parse-test.js
@@ -10,6 +10,7 @@ describe("Testing native BigInt support: parse", function () {
     return;
   }
   var input = '{"big":92233720368547758070,"small":123,"deci":1234567890.0123456,"shortExp":1.79e+308,"longExp":1.7976931348623157e+308}';
+  var infInput = '{"upperInf":1.797693134862316e+308,"lowerInf":-1.797693134862316e+308}';
 
   it("Should show JSONbig does support parsing native BigInt", function (done) {
     var JSONbig = require('../index')({
@@ -69,6 +70,26 @@ describe("Testing native BigInt support: parse", function () {
     var obj = JSONbig.parse(input);
     var output = JSONbig.stringify(obj);
     expect(output).to.equal(input);
+    done();
+  });
+
+  it(`Should show JSONbig parses a number bigger than the upper infinity limit (> 1.797693134862315E+308) as Infinity`, function (done) {
+    var JSONbig = require('../index')({
+      "alwaysParseAsBig": true,
+      "useNativeBigInt": true
+    });
+    var obj = JSONbig.parse(infInput);
+    expect(obj.upperInf, "upper infinity").to.equal(Infinity);
+    done();
+  });
+
+  it(`Should show JSONbig parses a number smaller than the lower infinity limit (< -1.797693134862315E+308) as -Infinity`, function (done) {
+    var JSONbig = require('../index')({
+      "alwaysParseAsBig": true,
+      "useNativeBigInt": true
+    });
+    var obj = JSONbig.parse(infInput);
+    expect(obj.lowerInf, "lower infinity").to.equal(-Infinity);
     done();
   });
 });


### PR DESCRIPTION
Hi Andrey, 
I'm creating this pull request based on the work that Hao @haoadoresorange did.
@haoadoresorange proposed some improvements after rewriting this project in TypeScript, he is actually busy finishing his graduation thesis (Dorsal laboratory - Polytechnique Montreal), so I will be rewriting them in JavaScript in order to merge them in your main repository.

In this first pull request, we are distinguishing a bad number from an infinite number by returning +/- infinity when the number is higher /lower than the +/- infinity limit.
The unit tests covering that are added too. 