### PR TITLE
Fix parsing of very large bigints

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,6 +7,11 @@ var BigNumber = null;
 const suspectProtoRx = /(?:_|\\u005[Ff])(?:_|\\u005[Ff])(?:p|\\u0070)(?:r|\\u0072)(?:o|\\u006[Ff])(?:t|\\u0074)(?:o|\\u006[Ff])(?:_|\\u005[Ff])(?:_|\\u005[Ff])/;
 const suspectConstructorRx = /(?:c|\\u0063)(?:o|\\u006[Ff])(?:n|\\u006[Ee])(?:s|\\u0073)(?:t|\\u0074)(?:r|\\u0072)(?:u|\\u0075)(?:c|\\u0063)(?:t|\\u0074)(?:o|\\u006[Ff])(?:r|\\u0072)/;
 
+// (c) CC BY-SA 4.0
+// https://stackoverflow.com/a/57342060
+// Modified to remove support for + prefix
+const numberRx = /^\s*-?(\d+|\d*\.\d+|\d+\.\d*)([eE][+-]?\d+)?\s*$/;
+
 /*
     json_parse.js
     2012-06-20
@@ -202,7 +207,7 @@ var json_parse = function (options) {
         }
       }
       number = +string;
-      if (!isFinite(number)) {
+      if (!numberRx.test(string)) {
         error('Bad number');
       } else {
         if (BigNumber == null) BigNumber = require('bignumber.js');

--- a/test/bigint-parse-test.js
+++ b/test/bigint-parse-test.js
@@ -9,7 +9,7 @@ describe("Testing native BigInt support: parse", function () {
     console.log('No native BigInt');
     return;
   }
-  var input = '{"big":92233720368547758070,"small":123,"deci":1234567890.0123456,"shortExp":1.79e+308,"longExp":1.7976931348623157e+308}';
+  var input = `{"huge":1${'0'.repeat(309)},"big":92233720368547758070,"small":123,"deci":1234567890.0123456,"shortExp":1.79e+308,"longExp":1.7976931348623157e+308}`;
 
   it("Should show JSONbig does support parsing native BigInt", function (done) {
     var JSONbig = require('../index')({
@@ -19,6 +19,8 @@ describe("Testing native BigInt support: parse", function () {
     expect(obj.small, "small int").to.equal(123);
     expect(obj.big.toString(), "big int").to.equal("92233720368547758070");
     expect(typeof obj.big, "big int").to.equal('bigint');
+    expect(obj.huge.toString(), "huge int").to.equal(`1${'0'.repeat(309)}`);
+    expect(typeof obj.huge, "huge int").to.equal('bigint');
     done();
   });
 


### PR DESCRIPTION
This is something of a follow-up to #62. It replaces the `isFinite` check that keeps us from being able to parse large BigInts.

I will note that this changes the behaviour for something like `JSONbig.parse('{"foo":1.99+308}')`. Earlier that would throw an error, but now it returns `Infinity`. If you want me to handle that edge case separately or have suggestions for alternatives to using a regex for the validity check, let me know.